### PR TITLE
sort repos alphabetically so the manifest is canonicalized

### DIFF
--- a/lib/manifestly/manifest.rb
+++ b/lib/manifestly/manifest.rb
@@ -40,6 +40,9 @@ module Manifestly
 
     def write(filename)
       File.open(filename, 'w') do |file|
+        @items.sort_by! do |item|
+          item[:repository_name]
+        end
         @items.each do |item|
           file.write(item.to_file_string + "\n")
         end


### PR DESCRIPTION
I _think_ this works. The existing tests all pass, but I was unable to add a repo to manifestly (not clear from the commandline help) :smile: 

But this makes diffing manifests easier. refs #3 #2