### PR TITLE
Non-interactive create

### DIFF
--- a/lib/manifestly/cli.rb
+++ b/lib/manifestly/cli.rb
@@ -94,6 +94,18 @@ module Manifestly
 
       NON-INTERACTIVE CREATION
 
+      Three options are of particular use when using non-interactive creation:
+
+      --add: a space-separated list of repository paths to add, can be relative or
+      absolute path names; if relative, manifestly tries to find them based on the
+      --search_paths option. The special all option adds all available repos.
+
+      --remove: a space-separated list of repository paths to remove, only useful
+      if you've also passed a --based_on manifest as a starting point.
+
+      --save_as: lets you provide a name for the created manifest, otherwise defaults
+      to a timestamp name with a random hex hash
+
       Examples:
 
       $ manifestly create --search_paths=.. --add=repo1 repo2 repo3
@@ -101,6 +113,10 @@ module Manifestly
       The above is the same as:
 
       $ manifestly create --add=../repo1 ../repo2 ../repo3
+
+      You can add "all":
+
+      $ manifestly create --add=all
 
       $ manifestly create --based_on=existing.manifest --remove=repo1 --save_as=new.manifest
 

--- a/lib/manifestly/manifest.rb
+++ b/lib/manifestly/manifest.rb
@@ -11,6 +11,10 @@ module Manifestly
       @items.push(Manifestly::ManifestItem.new(repository))
     end
 
+    def remove_repository(repository)
+      @items.reject!{|item| item.repository.display_name == repository.display_name}
+    end
+
     def add_item(manifest_item)
       @items.push(manifest_item)
     end
@@ -40,9 +44,7 @@ module Manifestly
 
     def write(filename)
       File.open(filename, 'w') do |file|
-        @items.sort_by! do |item|
-          item[:repository_name]
-        end
+        @items.sort_by!(&:repository_name)
         @items.each do |item|
           file.write(item.to_file_string + "\n")
         end

--- a/lib/manifestly/repository.rb
+++ b/lib/manifestly/repository.rb
@@ -45,6 +45,14 @@ module Manifestly
       end
     end
 
+    def has_commits?
+      begin
+        git && commits
+      rescue NoCommitsError
+        false
+      end
+    end
+
     def fetch
       git.fetch
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'manifestly'
+require 'byebug'
 
 def absolutize_gem_path(path)
   File.join(File.dirname(__FILE__), '..', path)


### PR DESCRIPTION
Changes Manifestly to use non-interactive create by default.  If you want interactive create you'll have to pass the `-i` or `--interactive` flags.

With non-interactive creation, you have the following new flags:

* `--add` a space-separated list of repository paths to add, can be relative or absolute path names; if relative, manifestly tries to find them based on the `--search_paths` option.  The special `all` option adds all available repos.
* `--remove` a space-separated list of repository paths to remove, only useful if you've also passed a `--based_on` manifest as a starting point.  
* `--save_as` lets you provide a name for the created manifest, otherwise defaults to a timestamp name with a random hex hash

**Examples:**

      $ manifestly create --search_paths=.. --add=repo1 repo2 repo3

The above is the same as:

      $ manifestly create --add=../repo1 ../repo2 ../repo3

You can add "all":

      $ manifestly create --add=all

      $ manifestly create --based_on=existing.manifest --remove=repo1 --save_as=new.manifest

cc @cnuber @kevinburleigh75 @philschatz 