### PR TITLE
Manifest tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.2.3
 cache: bundler
 before_install: gem install bundler
+before_script:
+  - git config --global user.email "cyrus@redblock.com"
+  - git config --global user.name "Cyrus Redblock"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Both `create` and `apply` take a `--search-paths` option to specify where the re
 
 `create` by default is non-interactive (see `$>manifestly help create`) but there is an interactive option that will show you a blank manifest and give you options to add or remove repositories, or to choose the manifest commit for an existing repository.  When repositories are added, their latest commit is listed.  All commits seen during manifest creation are local commits only -- this tool does not look up remote commits.
 
-### push
+### upload
 
 To push a manifest file you have created, call:
 
@@ -56,6 +56,18 @@ To apply a manifest file to your local repositories... instructions TBD, see bui
 ### list
 
 To list available manifest files... instructions TBD, see built-in help
+
+### tag
+
+You can add a tag to a manifest.  The same tag can be added multiple times (under the covers, Manifestly adds some unique characters to the tag you provide).
+
+See `$> manifestly help tag`.
+
+### find
+
+You can retrieve manifest SHAs for tags you've added.
+
+See `$> manifestly help find`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Manifestly has built in help:
 
     $ manifestly help
 
+_Note_: underscores and hyphens are interchangeable in option names, e.g. `--search_paths=blah` is the same as `--search-paths=blah`.
+
 ### create
 
 To create a new manifest, run

--- a/lib/manifestly.rb
+++ b/lib/manifestly.rb
@@ -6,4 +6,24 @@ require_relative 'manifestly/manifest'
 require_relative 'manifestly/ui'
 require_relative 'manifestly/cli'
 
-module Manifestly; end
+module Manifestly
+
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    class Configuration
+      attr_accessor :cached_repos_root_dir
+
+      def initialize
+        reset!
+      end
+
+      def reset!
+        @cached_repos_root_dir = '.'
+      end
+    end
+  end
+
+end

--- a/lib/manifestly/cli.rb
+++ b/lib/manifestly/cli.rb
@@ -98,17 +98,17 @@ module Manifestly
 
       --add: a space-separated list of repository paths to add, can be relative or
       absolute path names; if relative, manifestly tries to find them based on the
-      --search_paths option. The special all option adds all available repos.
+      --search-paths option. The special all option adds all available repos.
 
       --remove: a space-separated list of repository paths to remove, only useful
-      if you've also passed a --based_on manifest as a starting point.
+      if you've also passed a --based-on manifest as a starting point.
 
-      --save_as: lets you provide a name for the created manifest, otherwise defaults
+      --save-as: lets you provide a name for the created manifest, otherwise defaults
       to a timestamp name with a random hex hash
 
       Examples:
 
-      $ manifestly create --search_paths=.. --add=repo1 repo2 repo3
+      $ manifestly create --search-paths=.. --add=repo1 repo2 repo3
 
       The above is the same as:
 
@@ -118,7 +118,7 @@ module Manifestly
 
       $ manifestly create --add=all
 
-      $ manifestly create --based_on=existing.manifest --remove=repo1 --save_as=new.manifest
+      $ manifestly create --based-on=existing.manifest --remove=repo1 --save-as=new.manifest
 
       INTERACTIVE CREATION
 
@@ -167,10 +167,10 @@ module Manifestly
       $ manifestly create -i\x5
       Create manifest from scratch with the default search path
 
-      $ manifestly create -i --search_paths=..\x5
+      $ manifestly create -i --search-paths=..\x5
       Create manifest looking for repositories one dir up
 
-      $ manifestly create -i --based_on=~my.manifest --search_paths=~jim/repos\x5
+      $ manifestly create -i --based-on=~my.manifest --search-paths=~jim/repos\x5
       Create manifest starting from an existing one
     DESC
     def create
@@ -346,11 +346,11 @@ module Manifestly
 
       #{Rainbow("Examples:").bright}
 
-      $> manifestly find --tag=release-to-qa --repo=org/some_repo --repo_file=foo\x5
+      $> manifestly find --tag=release-to-qa --repo=org/some_repo --repo-file=foo\x5
       fe10b5fdb9e2559a7b7f9268e9f3b9cff840f5cb\x5
       9fc60bee7cc80ce85ad2c066bf251be44f8ad8f1\x5
 
-      $> manifestly find --tag=release-to-qa --repo=org/some_repo --repo_file=foo --limit=1\x5
+      $> manifestly find --tag=release-to-qa --repo=org/some_repo --repo-file=foo --limit=1\x5
       fe10b5fdb9e2559a7b7f9268e9f3b9cff840f5cb
     DESC
     repo_option
@@ -512,7 +512,7 @@ module Manifestly
         Manifest.read(file, available_repositories)
       rescue Manifestly::ManifestItem::RepositoryNotFound
         say "Couldn't find all the repositories listed in #{file}.  " +
-            "Might need to specify --search_paths."
+            "Might need to specify --search-paths."
         nil
       end
     end

--- a/lib/manifestly/cli.rb
+++ b/lib/manifestly/cli.rb
@@ -162,7 +162,7 @@ module Manifestly
 
       (r)eturn - entering 'r' returns to the previous menu
 
-      Examples:
+      #{Rainbow("Examples:").bright}
 
       $ manifestly create -i\x5
       Create manifest from scratch with the default search path
@@ -293,7 +293,20 @@ module Manifestly
       present_list_menu(commits, show_author: true)
     end
 
-    desc "tag", ""
+    desc "tag", "Add a tag to a manifest"
+    long_desc <<-DESC
+      Add a tag (with optional message) to a manifest as identified by its SHA.
+
+      Tags are not currently ever removed from manifests, but the `find` command
+      has an option to only return info for the latest tag.
+
+      When you run this command, the tag is immediately pushed to the upstream
+      manifest repository.
+
+      #{Rainbow("Examples:").bright}
+
+      $> manifestly tag --repo=org/repo --sha=fe10b5fdb9 --tag=release-to-qa --message="howdy"
+    DESC
     repo_option
     method_option :sha,
                   desc: "The commit SHA of the manifest on the remote repository",
@@ -331,13 +344,13 @@ module Manifestly
       You can limit the number of returned SHAs with the `--limit` flag.
       Otherwise, all matching SHAs are returned.
 
-      Examples:
+      #{Rainbow("Examples:").bright}
 
-      $> manifestly find --tag=release-to-qa --repo=org/some_repo --repo_file=foo
-      fe10b5fdb9e2559a7b7f9268e9f3b9cff840f5cb
-      9fc60bee7cc80ce85ad2c066bf251be44f8ad8f1
+      $> manifestly find --tag=release-to-qa --repo=org/some_repo --repo_file=foo\x5
+      fe10b5fdb9e2559a7b7f9268e9f3b9cff840f5cb\x5
+      9fc60bee7cc80ce85ad2c066bf251be44f8ad8f1\x5
 
-      $> manifestly find --tag=release-to-qa --repo=org/some_repo --repo_file=foo --limit=1
+      $> manifestly find --tag=release-to-qa --repo=org/some_repo --repo_file=foo --limit=1\x5
       fe10b5fdb9e2559a7b7f9268e9f3b9cff840f5cb
     DESC
     repo_option
@@ -355,7 +368,7 @@ module Manifestly
     def find
       repository = Repository.load_cached(options[:repo], update: true)
       shas = repository.get_shas_with_tag(tag: options[:tag], file: options[:repo_file])
-      options[:limit] ? shas.take(options[:limit]) : shas
+      options[:limit] ? shas.take(options[:limit].to_i) : shas
     end
 
     protected

--- a/lib/manifestly/diff.rb
+++ b/lib/manifestly/diff.rb
@@ -49,6 +49,7 @@ module Manifestly
     def initialize(diff_string)
       file_strings = diff_string.split("diff --git ")
       file_strings.reject!(&:blank?)
+      file_strings.reject!{|str| str.starts_with?("commit ")} # from 'git show' output
       @files = file_strings.collect{|file_string| File.new(file_string)}
     end
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,11 @@
+## specs
+
+My first attempt to have realistic specs was to make some canned git repos in the
+`fixtures` directory and then to copy them to temp directories during spec runs.
+See the `fixtures/scenarios` directory and the other repo directories in `fixtures`.
+
+I later had the idea to just set up test git repos in temp directories on the fly.
+These are run the same was as the `.scenario` files, but the scenarios are just
+written inline in the specs.
+
+If you write specs, you can go either way.

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Manifestly::CLI do
+
+  describe 'create' do
+
+    it 'creates a manifest non-interactively' do
+      Scenarios.run('create') do |dirs|
+        suppress_output do
+          Manifestly::CLI.start(%W[create --no-interactive --search_paths=#{dirs[:locals]} --add=all --save_as=#{dirs[:root]}/my.manifest])
+        end
+
+        manifest = File.open("#{dirs[:root]}/my.manifest").read
+
+        expect(manifest).to eq(
+          "app_repo_1 @ baff0b6df2f5ae88df375c9e3787bf0f95632431\n" \
+          "app_repo_2 @ 2ef6871889268957db945fc7e63de553a5ff41d8\n"
+        )
+      end
+    end
+
+  end
+
+  describe 'tag' do
+
+    it 'adds a tag to a manifest repository' do
+      Scenarios.run('tag') do |dirs|
+        suppress_output do
+          Manifestly::CLI.start(%W[tag --repo=#{dirs[:remotes]}/manifest_repo_1 --sha=65cebfae2 --tag=release-to-qa])
+        end
+
+        # debugger
+        # puts 'hi'
+
+      end
+    end
+
+  end
+
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -21,17 +21,69 @@ describe Manifestly::CLI do
 
   end
 
-  describe 'tag' do
+  describe '#tag and #find' do
 
-    it 'adds a tag to a manifest repository' do
-      Scenarios.run('tag') do |dirs|
-        suppress_output do
-          Manifestly::CLI.start(%W[tag --repo=#{dirs[:remotes]}/manifest_repo_1 --sha=65cebfae2 --tag=release-to-qa])
+    it 'adds and finds tags on a manifest repository' do
+      Scenarios.run(inline: <<-SETUP
+        git init -q remote
+        cd remote
+        touch foo.manifest
+        git add . && git commit -q -m "."
+        git rev-parse HEAD > ../sha_0.txt
+        touch bar.manifest
+        git add . && git commit -q -m "."
+        git rev-parse HEAD > ../sha_1.txt
+        echo blah > foo.manifest
+        git add . && git commit -q -m "."
+        git rev-parse HEAD > ../sha_2.txt
+      SETUP
+    ) do |dirs|
+        shas = %w(sha_0 sha_1 sha_2).collect do |sha|
+          File.open("#{dirs[:root]}/#{sha}.txt").read.chomp
         end
 
-        # debugger
-        # puts 'hi'
+        # Test easy case of one file, one tag
 
+        suppress_output do
+          Manifestly::CLI.start(%W[tag --repo=#{dirs[:root]}/remote --sha=#{shas[0]} --tag=release-to-qa --message="howdy"])
+        end
+
+        expect(
+          Manifestly::CLI.start(%W[find --repo=#{dirs[:root]}/remote --repo_file=foo.manifest --tag=release-to-qa])
+        ).to eq [shas[0]]
+
+        # Test can filter based on different file
+
+        suppress_output do
+          Manifestly::CLI.start(%W[tag --repo=#{dirs[:root]}/remote --sha=#{shas[1]} --tag=release-to-qa])
+        end
+
+        expect(
+          Manifestly::CLI.start(%W[find --repo=#{dirs[:root]}/remote --repo_file=bar.manifest --tag=release-to-qa])
+        ).to eq [shas[1]]
+
+        suppress_output do
+          Manifestly::CLI.start(%W[tag --repo=#{dirs[:root]}/remote --sha=#{shas[2]} --tag=release-to-qa])
+        end
+
+        # Test what happens when multiple of "same" tag on one file
+
+        expect(
+          Manifestly::CLI.start(%W[find --repo=#{dirs[:root]}/remote --repo_file=foo.manifest --tag=release-to-qa])
+        ).to eq [shas[2], shas[0]]
+
+        expect(
+          Manifestly::CLI.start(%W[find --repo=#{dirs[:root]}/remote --repo_file=foo.manifest --tag=release-to-qa --limit=3])
+        ).to eq [shas[2], shas[0]]
+
+        expect(
+          Manifestly::CLI.start(%W[find --repo=#{dirs[:root]}/remote --repo_file=foo.manifest --tag=release-to-qa --limit=1])
+        ).to eq [shas[2]]
+
+        # Check that tags made it to remote
+
+        git = Git.open("#{dirs[:root]}/remote")
+        expect(git.tags.count).to eq 3
       end
     end
 

--- a/spec/fixtures/app_repos/non_repo_dir/readme.txt
+++ b/spec/fixtures/app_repos/non_repo_dir/readme.txt
@@ -1,1 +1,0 @@
-This directory will be on search_paths, but is intentionally not a repository

--- a/spec/fixtures/manifest_repos/.gitkeep
+++ b/spec/fixtures/manifest_repos/.gitkeep
@@ -1,1 +1,0 @@
-.gitkeep

--- a/spec/fixtures/scenarios/create.scenario
+++ b/spec/fixtures/scenarios/create.scenario
@@ -1,0 +1,8 @@
+mkdir remotes
+mkdir locals
+
+cp -r <%= @fixtures_dir %>/app_repos/app_repo_1 remotes
+cp -r <%= @fixtures_dir %>/app_repos/app_repo_2 remotes
+
+git clone remotes/app_repo_1 locals/app_repo_1 &> /dev/null
+git clone remotes/app_repo_2 locals/app_repo_2 &> /dev/null

--- a/spec/fixtures/scenarios/create.scenario
+++ b/spec/fixtures/scenarios/create.scenario
@@ -1,8 +1,0 @@
-mkdir remotes
-mkdir locals
-
-cp -r <%= @fixtures_dir %>/app_repos/app_repo_1 remotes
-cp -r <%= @fixtures_dir %>/app_repos/app_repo_2 remotes
-
-git clone remotes/app_repo_1 locals/app_repo_1 &> /dev/null
-git clone remotes/app_repo_2 locals/app_repo_2 &> /dev/null

--- a/spec/fixtures/scenarios/tag.scenario
+++ b/spec/fixtures/scenarios/tag.scenario
@@ -1,0 +1,5 @@
+cd <%= @dir %>
+
+mkdir remotes
+
+cp -r <%= @fixtures_dir %>/manifest_repos/manifest_repo_1 remotes

--- a/spec/fixtures/scenarios/tag.scenario
+++ b/spec/fixtures/scenarios/tag.scenario
@@ -1,5 +1,0 @@
-cd <%= @dir %>
-
-mkdir remotes
-
-cp -r <%= @fixtures_dir %>/manifest_repos/manifest_repo_1 remotes

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -2,22 +2,104 @@ require 'spec_helper'
 
 describe Manifestly::Repository do
 
-  it 'should get github_name for ssh clone repos' do
+  it 'should get github_name_or_path for ssh clone repos' do
     origin = instance_double("Git::Remote", url: "git@github.com:organization/reponame.git")
     expect_any_instance_of(Manifestly::Repository).to receive(:origin).and_return(origin, origin)
-    expect(Manifestly::Repository.new('').github_name).to eq "organization/reponame"
+    expect(Manifestly::Repository.new('').github_name_or_path).to eq "organization/reponame"
   end
 
-  it 'should get github_name for http cloned repos' do
+  it 'should get github_name_or_path for http cloned repos' do
     origin = instance_double("Git::Remote", url: "http://github.com/organization/reponame")
     expect_any_instance_of(Manifestly::Repository).to receive(:origin).and_return(origin, origin)
-    expect(Manifestly::Repository.new('').github_name).to eq "organization/reponame"
+    expect(Manifestly::Repository.new('').github_name_or_path).to eq "organization/reponame"
   end
 
-  it 'should get github_name for httpS cloned repos' do
+  it 'should get github_name_or_path for httpS cloned repos' do
     origin = instance_double("Git::Remote", url: "https://github.com/organization/reponame")
     expect_any_instance_of(Manifestly::Repository).to receive(:origin).and_return(origin, origin)
-    expect(Manifestly::Repository.new('').github_name).to eq "organization/reponame"
+    expect(Manifestly::Repository.new('').github_name_or_path).to eq "organization/reponame"
+  end
+
+  it 'should get the right file for a given commit' do
+    Scenarios.run(inline: <<-SETUP
+        git init -q repo
+        cd repo
+        echo apple > apple.txt
+        git add . && git commit -q -m "."
+        git rev-parse HEAD > ../a_sha.txt
+        echo banana > banana.txt
+        git add . && git commit -q -m "."
+        git rev-parse HEAD > ../b_sha.txt
+        echo carrot > carrot.txt
+        git add . && git commit -q -m "."
+      SETUP
+    ) do |dirs|
+      a_sha = File.open("#{dirs[:root]}/a_sha.txt").read.chomp
+      b_sha = File.open("#{dirs[:root]}/b_sha.txt").read.chomp
+
+      repo = Manifestly::Repository.load("#{dirs[:root]}/repo")
+
+      file = repo.get_commit_file(b_sha)
+      expect(file.to_name).to eq 'banana.txt'
+      expect(file.to_content).to eq 'banana'
+
+      file = repo.get_commit_file(a_sha)
+      expect(file.to_name).to eq 'apple.txt'
+      expect(file.to_content).to eq 'apple'
+    end
+  end
+
+  it 'should tag scoped to a file' do
+    Scenarios.run(inline: <<-SETUP
+        git init -q remote
+        cd remote
+        touch file.txt
+        git add . && git commit -q -m "."
+        cd ..
+        git clone -q remote local
+        cd local
+        git rev-parse HEAD > ../sha.txt
+      SETUP
+    ) do |dirs|
+      sha = File.open("#{dirs[:root]}/sha.txt").read.chomp
+      local = Manifestly::Repository.load("#{dirs[:root]}/local")
+      local.tag_scoped_to_file(tag: 'release-to-qa', sha: sha, message: 'hi', push: true)
+
+      remote = Git.open("#{dirs[:root]}/remote")
+      expect(remote.describe(sha)).to match /.+\/release-to-qa/
+    end
+  end
+
+  it 'should return ordered shas tag / file combinations' do
+    Scenarios.run(inline: <<-SETUP
+        git init -q repo
+        cd repo
+        touch file.txt
+        git add . && git commit -q -m "."
+        git rev-parse HEAD > ../sha_1.txt
+        touch other.txt
+        git add . && git commit -q -m "."
+        git rev-parse HEAD > ../sha_2.txt
+        echo blah > file.txt
+        git add . && git commit -q -m "."
+        git rev-parse HEAD > ../sha_3.txt
+      SETUP
+    ) do |dirs|
+      shas = %w(sha_1 sha_2 sha_3).collect do |sha|
+        File.open("#{dirs[:root]}/#{sha}.txt").read.chomp
+      end
+
+      repo = Manifestly::Repository.load("#{dirs[:root]}/repo")
+      repo.tag_scoped_to_file(tag: 'release-to-qa', sha: shas[0], message: 'hi')
+      repo.tag_scoped_to_file(tag: 'release-to-qa', sha: shas[1], message: 'howdy')
+      repo.tag_scoped_to_file(tag: 'release-to-qa', sha: shas[2])
+
+      expect(repo.get_shas_with_tag(tag: 'release-to-qa', file: 'file.txt')).to eq [shas[2], shas[0]]
+      expect(repo.get_shas_with_tag(tag: 'release-to-qa', file: 'file.txt', order: :ascending)).to eq [shas[0], shas[2]]
+      expect(repo.get_shas_with_tag(tag: 'release-to-qa', file: 'other.txt')).to eq [shas[1]]
+      expect(repo.get_shas_with_tag(tag: 'blah', file: 'file.txt')).to be_empty
+      expect(repo.get_shas_with_tag(tag: 'release-to-qa')).to eq [shas[2], shas[1], shas[0]]
+    end
   end
 
 end

--- a/spec/scenarios.rb
+++ b/spec/scenarios.rb
@@ -8,16 +8,16 @@ class Scenarios
     new.run(name, &block)
   end
 
-  def run(name, &block)
+  def run(name_or_options, &block)
     @dir = Dir.mktmpdir('manifestly-spec-')
     @fixtures_dir = absolutize_gem_path("./spec/fixtures")
 
     begin
       Manifestly.configuration.cached_repos_root_dir = @dir
 
-      scenario = name.is_a?(Hash) ?
-                   name[:inline] :
-                   File.open(absolutize_gem_path("./spec/fixtures/scenarios/#{name}.scenario")).read
+      scenario = name_or_options.is_a?(Hash) ?
+                   name_or_options[:inline] :
+                   File.open(absolutize_gem_path("./spec/fixtures/scenarios/#{name_or_options}.scenario")).read
 
       scenario = "cd #{@dir}\n" + scenario
       scenario = ERB.new(scenario).result(binding())

--- a/spec/scenarios.rb
+++ b/spec/scenarios.rb
@@ -1,0 +1,44 @@
+require 'tmpdir'
+require 'erb'
+require 'fileutils'
+
+class Scenarios
+
+  def self.run(name, &block)
+    new.run(name, &block)
+  end
+
+  def run(name, &block)
+    @dir = Dir.mktmpdir('manifestly-spec-')
+    @fixtures_dir = absolutize_gem_path("./spec/fixtures")
+
+    begin
+      Manifestly.configuration.cached_repos_root_dir = @dir
+
+      scenario = name.is_a?(Hash) ?
+                   name[:inline] :
+                   File.open(absolutize_gem_path("./spec/fixtures/scenarios/#{name}.scenario")).read
+
+      scenario = "cd #{@dir}\n" + scenario
+      scenario = ERB.new(scenario).result(binding())
+      # scenario = scenario.split("\n").collect{|line| line.starts_with?("git ") ? "#{line} &> /dev/null" : line}.join("\n")
+
+      suppress_output { system scenario }
+
+      dirs = {
+        root: @dir,
+        locals: "#{@dir}/locals",
+        remotes: "#{@dir}/remotes"
+      }
+
+      block.call(dirs)
+    rescue StandardError => e
+      puts "Exception: #{e.inspect}"
+      raise e
+    ensure
+      Manifestly.configuration.reset!
+      FileUtils.rm_r @dir
+    end
+  end
+
+end

--- a/spec/scenarios.rb
+++ b/spec/scenarios.rb
@@ -21,7 +21,6 @@ class Scenarios
 
       scenario = "cd #{@dir}\n" + scenario
       scenario = ERB.new(scenario).result(binding())
-      # scenario = scenario.split("\n").collect{|line| line.starts_with?("git ") ? "#{line} &> /dev/null" : line}.join("\n")
 
       suppress_output { system scenario }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'manifestly'
 require 'byebug'
+require 'scenarios'
 
 def absolutize_gem_path(path)
   File.join(File.dirname(__FILE__), '..', path)
@@ -18,5 +19,20 @@ RSpec.configure do |config|
     end
 
     result
+  end
+
+  def suppress_output
+    original_stderr = $stderr
+    original_stdout = $stdout
+
+    begin
+      $stderr = File.open(File::NULL, "w")
+      $stdout = File.open(File::NULL, "w")
+
+      yield
+    ensure
+      $stderr = original_stderr
+      $stdout = original_stdout
+    end
   end
 end


### PR DESCRIPTION
Add ability to add tags to manifests and to find manifest SHAs based on those tags.

From the inline help:

## tag

```
Usage:
  manifestly tag --repo --sha --tag

Options:
  --repo       # The github manifest repository to use, given as 'organization/reponame'
  --sha        # The commit SHA of the manifest on the remote repository
  --tag        # The value of the tag
  [--message]  # An optional message on the tag

Description:
  Add a tag (with optional message) to a manifest as identified by its SHA.

  Tags are not currently ever removed from manifests, but the `find` command has an 
  option to only return info for the latest tag.

  When you run this command, the tag is immediately pushed to the upstream 
  manifest repository.

  Examples:

  $> manifestly tag --repo=org/repo --sha=fe10b5fdb9 --tag=release-to-qa --message="howdy"
```

## find

```
Usage:
  manifestly find --repo --repo-file --tag

Options:
  --repo       # The github manifest repository to use, given as 'organization/reponame'
  --repo-file  # The name of the manifest to look for tags on
  --tag        # The value of the tag
  [--limit]    # The number of results to return

Description:
  Returns a list of manifest SHAs that have the specified tag on the specified repository file.

  SHAs are sorted in order of descending tag timestamp. Note that these timestamps are 
  unavoidably linked to the time on the machine doing the tagging, so it is possible to have 
  unintended orderings if tagging machine times are inaccurate or if tags are created at near
  simultaneous times on multiple machines. Time zones of those machines do not matter.

  You can limit the number of returned SHAs with the `--limit` flag. Otherwise, all matching
  SHAs are returned.

  Examples:

  $> manifestly find --tag=release-to-qa --repo=org/some_repo --repo-file=foo
   fe10b5fdb9e2559a7b7f9268e9f3b9cff840f5cb
   9fc60bee7cc80ce85ad2c066bf251be44f8ad8f1

  $> manifestly find --tag=release-to-qa --repo=org/some_repo --repo-file=foo --limit=1
   fe10b5fdb9e2559a7b7f9268e9f3b9cff840f5cb
```
