### PR TITLE
Manifest diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ You can retrieve manifest SHAs for tags you've added.
 
 See `$> manifestly help find`.
 
+### diff
+
+You can diff two manifests, resulting in markdown output that lists the PRs merged between manifests for each application repository listed in the "to" manifest.
+
+See `$> manifestly help diff`.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/manifestly.rb
+++ b/lib/manifestly.rb
@@ -1,8 +1,10 @@
 require_relative "manifestly/version"
 require_relative 'manifestly/utilities'
+require_relative 'manifestly/commit'
 require_relative 'manifestly/diff'
 require_relative 'manifestly/repository'
 require_relative 'manifestly/manifest'
+require_relative 'manifestly/manifest_diff'
 require_relative 'manifestly/ui'
 require_relative 'manifestly/cli'
 

--- a/lib/manifestly/cli.rb
+++ b/lib/manifestly/cli.rb
@@ -372,6 +372,20 @@ module Manifestly
     end
 
     desc "diff", "Show PR commits between two manifests across its repos"
+    long_desc <<-DESC
+      Runs a diff between two manifests (as identified by their commit SHAs) and
+      produces output (by default in markdown) that lists the PRs that were merged
+      between the manifests for each application repository listed in the "to"
+      manifest.
+
+      Up-to-date repositories are required wherever you are running manifestly,
+      and will need to be referenced with the normal --search-paths option (unless
+      they are in the default path).
+
+      #{Rainbow("Examples:").bright}
+
+      $> manifestly diff --repo=org/some_repo --from-sha=fe10b5fdb9e --to-sha=9fc60bee7c > changes.md
+    DESC
     search_paths_option
     repo_option
     method_option :from_sha,

--- a/lib/manifestly/cli.rb
+++ b/lib/manifestly/cli.rb
@@ -402,6 +402,13 @@ module Manifestly
       repository = Repository.load_cached(options[:repo], update: true)
       from_manifest = load_manifest(repository: repository, sha: options[:from_sha])
       to_manifest = load_manifest(repository: repository, sha: options[:to_sha])
+
+      if !from_manifest || !to_manifest
+        say("Could not load the 'from' manifest so cannot continue with the diff.") if !from_manifest
+        say("Could not load the 'to' manifest so cannot continue with the diff.") if !to_manifest
+        return
+      end
+
       manifest_diff = ManifestDiff.new(from_manifest, to_manifest)
       manifest_diff.to_markdown
     end
@@ -557,8 +564,8 @@ module Manifestly
           say "Missing arguments when trying to load manifest"
           nil
         end
-      rescue Manifestly::ManifestItem::RepositoryNotFound
-        say "Couldn't find all the repositories listed in the manifest.  " +
+      rescue Manifestly::ManifestItem::RepositoryNotFound => e
+        say "Couldn't find the #{e.message} repository listed in the manifest.  " +
             "Might need to specify --search-paths."
         nil
       end

--- a/lib/manifestly/cli.rb
+++ b/lib/manifestly/cli.rb
@@ -175,7 +175,7 @@ module Manifestly
     DESC
     def create
       manifest = if options[:based_on]
-        read_manifest(options[:based_on]) || return
+        load_manifest(file: options[:based_on]) || return
       else
         Manifest.new
       end
@@ -205,7 +205,7 @@ module Manifestly
     DESC
     def apply
       begin
-        manifest = read_manifest(options[:file]) || return
+        manifest = load_manifest(file: options[:file]) || return
       rescue Manifestly::ManifestItem::MultipleSameNameRepositories => e
         say "Multiple repositories have the same name (#{e.message}) so we " +
             "can't apply the manifest. Try limiting the search_paths or " +
@@ -371,6 +371,27 @@ module Manifestly
       options[:limit] ? shas.take(options[:limit].to_i) : shas
     end
 
+    desc "diff", "Show PR commits between two manifests across its repos"
+    search_paths_option
+    repo_option
+    method_option :from_sha,
+                  desc: "The commit SHA of the manifest on the remote repository to diff from",
+                  type: :string,
+                  banner: '',
+                  required: true
+    method_option :to_sha,
+                  desc: "The commit SHA of the manifest on the remote repository to diff from",
+                  type: :string,
+                  banner: '',
+                  required: true
+    def diff
+      repository = Repository.load_cached(options[:repo], update: true)
+      from_manifest = load_manifest(repository: repository, sha: options[:from_sha])
+      to_manifest = load_manifest(repository: repository, sha: options[:to_sha])
+      manifest_diff = ManifestDiff.new(from_manifest, to_manifest)
+      manifest_diff.to_markdown
+    end
+
     protected
 
     def present_create_menu(manifest)
@@ -507,11 +528,23 @@ module Manifestly
       end
     end
 
-    def read_manifest(file)
+    def load_manifest(options={})
       begin
-        Manifest.read(file, available_repositories)
+        if options[:file]
+          Manifest.read_file(options[:file], available_repositories)
+        elsif options[:repository] && options[:sha]
+          content = options[:repository].get_commit_content(options[:sha])
+          Manifest.read_lines(content, available_repositories).tap do |manifest|
+            manifest.manifest_repository = options[:repository]
+            manifest.manifest_sha = options[:sha]
+            manifest.manifest_file = options[:repository].get_commit_filename(options[:sha])
+          end
+        else
+          say "Missing arguments when trying to load manifest"
+          nil
+        end
       rescue Manifestly::ManifestItem::RepositoryNotFound
-        say "Couldn't find all the repositories listed in #{file}.  " +
+        say "Couldn't find all the repositories listed in the manifest.  " +
             "Might need to specify --search-paths."
         nil
       end
@@ -619,19 +652,12 @@ module Manifestly
           row do
             column "#{index}", align: 'right'
             column "#{commit.sha[0..9]}"
-            column "#{summarize_commit_message(commit)}"
+            column "#{Commit.new(commit).summarized_message}"
             column "#{commit.author.name[0..13]}" if options[:show_author]
             column "#{commit.date}"
           end
         end
       end
-    end
-
-    def summarize_commit_message(commit)
-      commit.message
-        .gsub(/Merge pull request (#\w+)( from [\w-]+\/[\w-]+)/, 'PR \1')
-        .gsub("\n",' ')
-        .gsub(/\s+/, ' ')[0..79]
     end
 
     def repository_choices(except_in_manifest=nil)

--- a/lib/manifestly/commit.rb
+++ b/lib/manifestly/commit.rb
@@ -1,0 +1,25 @@
+module Manifestly
+  class Commit
+
+    def initialize(commit)
+      @commit = commit
+    end
+
+    def is_pr?
+      @commit.message.starts_with?("Merge pull request")
+    end
+
+    def pr_number
+      match = @commit.message.match(/Merge pull request #(\d+)/)
+      match.nil? ? nil : match[1]
+    end
+
+    def summarized_message
+      @commit.message
+        .gsub(/Merge pull request (#\w+)( from [\w-]+\/[\w-]+)/, 'PR \1')
+        .gsub("\n",' ')
+        .gsub(/\s+/, ' ')[0..79]
+    end
+
+  end
+end

--- a/lib/manifestly/manifest.rb
+++ b/lib/manifestly/manifest.rb
@@ -29,17 +29,17 @@ module Manifestly
       @items[index]
     end
 
-    def self.read(filename, repositories)
-      manifest = Manifest.new
-
+    def self.read_file(filename, repositories)
       File.open(filename, 'r') do |file|
-        file.each_line do |line|
-          item = ManifestItem.from_file_string(line, repositories)
-          manifest.add_item(item)
-        end
+        read_lines(file, repositories)
       end
+    end
 
-      manifest
+    def self.read_lines(lines, repositories)
+      lines.split("\n").each_with_object(Manifest.new) do |line, manifest|
+        item = ManifestItem.from_file_string(line, repositories)
+        manifest.add_item(item)
+      end
     end
 
     def write(filename)
@@ -60,6 +60,11 @@ module Manifestly
     def empty?
       items.empty?
     end
+
+    # Some meta info that some callers want to attach to the manifest
+    attr_accessor :manifest_repository
+    attr_accessor :manifest_sha
+    attr_accessor :manifest_file
 
   end
 end

--- a/lib/manifestly/manifest_diff.rb
+++ b/lib/manifestly/manifest_diff.rb
@@ -24,7 +24,7 @@ module Manifestly
       def item_source_info
         new_item? ?
           " (new manifest entry)" :
-          " (#{from_sha[0..9]} to #{to_sha[0..9]})"
+          " (`#{from_sha[0..9]}` to `#{to_sha[0..9]}`)"
       end
 
       def new_item?
@@ -60,7 +60,7 @@ module Manifestly
               "1. #{entry}"
             end.join("\n")
 
-            is_rollback ? "These commits were *rolled back*:\n\n#{entries}" : entries
+            is_rollback ? "These commits were ***rolled back***:\n\n#{entries}" : entries
           end
         end
       end
@@ -90,7 +90,7 @@ module Manifestly
       to_sha = @to_manifest.manifest_sha
 
       if repository && file && from_sha && to_sha
-        "Comparing manifest *#{file}* on repository *#{repository.display_name}* from commit #{from_sha[0..9]} to #{to_sha[0..9]}."
+        "Comparing manifest ***#{file}*** on repository ***#{repository.display_name}*** from commit `#{from_sha[0..9]}` to `#{to_sha[0..9]}`."
       else
         "Manifest source info is *unknown*."
       end

--- a/lib/manifestly/manifest_diff.rb
+++ b/lib/manifestly/manifest_diff.rb
@@ -1,0 +1,100 @@
+module Manifestly
+  class ManifestDiff
+
+    class ItemDiff
+      def initialize(from_item, to_item)
+        @from_item = from_item
+        @to_item = to_item
+
+        @markdown = "## #{to_item.repository_name}#{item_source_info}\n\n#{commits_markdown}\n"
+      end
+
+      def to_markdown
+        @markdown
+      end
+
+      def from_sha
+        @from_item.commit.sha
+      end
+
+      def to_sha
+        @to_item.commit.sha
+      end
+
+      def item_source_info
+        new_item? ?
+          " (new manifest entry)" :
+          " (#{from_sha[0..9]} to #{to_sha[0..9]})"
+      end
+
+      def new_item?
+        @from_item.nil?
+      end
+
+      def commits_markdown
+        if new_item?
+          "* This manifest item was not in the prior manifest, so all of its commits are new."
+        else
+          repository = @from_item.repository
+          repository.toggle_prs_only
+
+          is_rollback = false
+
+          commits = repository.commits(between: [from_sha, to_sha])
+
+          if commits.size == 0
+            # This might be a rollback, so try them backwards
+            commits = repository.commits(between: [to_sha, from_sha])
+            is_rollback = commits.size != 0
+          end
+
+          if commits.size == 0
+            "* There were no pull requests merged in this range of commits."
+          else
+            entries = commits.collect do |commit|
+              wrapper = Commit.new(commit)
+              entry = wrapper.summarized_message
+
+              entry = "[#{entry}](https://github.com/#{repository.display_name}/pull/#{wrapper.pr_number})" if wrapper.is_pr?
+
+              "1. #{entry}"
+            end.join("\n")
+
+            is_rollback ? "These commits were *rolled back*:\n\n#{entries}" : entries
+          end
+        end
+      end
+    end
+
+    def initialize(from_manifest, to_manifest)
+      @from_manifest = from_manifest
+      @to_manifest = to_manifest
+
+      @item_diffs = @to_manifest.items.collect do |to_item|
+        from_item = @from_manifest.items.detect do |from_item|
+          from_item.repository_name == to_item.repository_name
+        end
+
+        ItemDiff.new(from_item, to_item)
+      end
+    end
+
+    def to_markdown
+      "# Manifest Diff\n\n#{manifest_source_info}\n\n#{@item_diffs.collect(&:to_markdown).join("\n")}"
+    end
+
+    def manifest_source_info
+      repository = @from_manifest.manifest_repository
+      file = @from_manifest.manifest_file
+      from_sha = @from_manifest.manifest_sha
+      to_sha = @to_manifest.manifest_sha
+
+      if repository && file && from_sha && to_sha
+        "Comparing manifest *#{file}* on repository *#{repository.display_name}* from commit #{from_sha[0..9]} to #{to_sha[0..9]}."
+      else
+        "Manifest source info is *unknown*."
+      end
+    end
+
+  end
+end

--- a/lib/manifestly/manifest_item.rb
+++ b/lib/manifestly/manifest_item.rb
@@ -39,8 +39,7 @@ module Manifestly
       raise(InvalidManifestItem, string) if repo_name.blank? || sha.blank?
 
       matching_repositories = repositories.select do |repo|
-        repo.github_name      == repo_name ||
-        repo.working_dir.to_s == repo_name
+        repo.display_name == repo_name
       end
 
       raise(MultipleSameNameRepositories, repo_name) if matching_repositories.size > 1

--- a/lib/manifestly/repository.rb
+++ b/lib/manifestly/repository.rb
@@ -85,9 +85,10 @@ module Manifestly
       git.push
     end
 
-    def commits
+    def commits(options={})
       begin
-        log = git.log(1000000).object('origin/master') # don't limit
+        log = git.log(1000000).object('master') # don't limit
+        log = log.between(options[:between][0], options[:between][1]) if options[:between]
         log = log.grep("Merge pull request") if @prs_only
         log.tap(&:first) # tap to force otherwise lazy checks
       rescue Git::GitExecuteError => e

--- a/spec/scenarios.rb
+++ b/spec/scenarios.rb
@@ -19,7 +19,9 @@ class Scenarios
                    name_or_options[:inline] :
                    File.open(absolutize_gem_path("./spec/fixtures/scenarios/#{name_or_options}.scenario")).read
 
+      scenario = scenario.split("\n").collect(&:strip).join("\n")
       scenario = "cd #{@dir}\n" + scenario
+      scenario = Scenarios.sub_aliases(scenario)
       scenario = ERB.new(scenario).result(binding())
 
       suppress_output { system scenario }
@@ -39,5 +41,37 @@ class Scenarios
       FileUtils.rm_r @dir
     end
   end
+
+  def self.sub_aliases(scenario)
+    scenario.split("\n").collect do |line|
+      sub_fake_commit(line)
+    end.join("\n")
+  end
+
+  def self.sub_fake_commit(line)
+    return line if !line.starts_with?("fake_commit")
+
+    options = parse_alias(line)
+
+    [
+      "cd #{options[:repo]}",
+      "touch foo",
+      "echo #{SecureRandom.hex(3)} >> foo",
+      "git add . && git commit -q -m '#{options[:comment]}'",
+      options[:sha] ? "#{options[:sha]}=\"$(git rev-parse HEAD)\"" : nil,
+      "cd .."
+    ].compact.join("\n")
+  end
+
+  def self.parse_alias(line)
+    options = line.split("|")
+    options = options[1..-1]  # ditch alias name
+    options = options.collect(&:strip)
+    options = options.each_with_object({}) do |option, hash|
+      parts = option.split(":").collect(&:strip)
+      hash[parts[0].to_sym] = parts[1]
+    end
+  end
+
 
 end

--- a/spec/scenarios_spec.rb
+++ b/spec/scenarios_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Scenarios do
+
+  it 'subs fake_commits' do
+    expect(Scenarios.sub_fake_commit("fake_commit | repo:blah | comment: How are you")).to match /\Acd blah\n.*\n.*\n.*How are you/
+  end
+
+  it 'subs aliases' do
+    input = "line1\nfake_commit|repo:blah|comment:hi|\nline 3"
+    expect(Scenarios.sub_aliases(input)).to match /line1\ncd blah\n.*\n.*\n.*'hi'\ncd ..\nline 3/
+  end
+
+end


### PR DESCRIPTION
Adds the ability to diff two manifests, resulting in markdown output that lists the PRs merged between manifests for each application repository listed in the "to" manifest.

Converting the output to HTML would be trivial by adding kramdown, if that's desirable.

## Usage:

```
Usage:
  manifestly diff --from-sha --repo --to-sha

Options:
  [--search-paths]  # A list of paths where git repositories can be found
                    # Default: .
  --repo            # The github manifest repository to use, given as 'organization/reponame'
  --from-sha        # The commit SHA of the manifest on the remote repository to diff from
  --to-sha          # The commit SHA of the manifest on the remote repository to diff from

Description:
  Runs a diff between two manifests (as identified by their commit SHAs) and produces 
  output (by default in markdown) that lists the PRs that were merged between the 
  manifests for each application repository listed in the "to" manifest.

  Up-to-date repositories are required wherever you are running manifestly, and will 
  need to be referenced with the normal --search-paths option (unless they are in the 
  default path).

  Examples:

  $> manifestly diff --repo=org/some_repo --from-sha=fe10b5fdb9e --to-sha=9fc60bee7c > changes.md
```

Here's an example of the output (from our spec testing this feature, so the links don't work because these aren't actual github repositories).  Below, "one", "two", etc would in real life be repos like "openstax/tutor-server".

# Manifest Diff

Comparing manifest ***foo*** on repository ***manifests*** from commit `ba2ab8e8ea` to `978bdd997f`.

## one (`3027aeac6c` to `efe09146ff`)

1. [PR #2 Added feature Y](https://github.com/one/pull/2)
1. [PR #1 Added import ability](https://github.com/one/pull/1)

## two (`24b7fea906` to `6ad6ff0e73`)

* There were no pull requests merged in this range of commits.

## three (new manifest entry)

* This manifest item was not in the prior manifest, so all of its commits are new.

## four (`bdc255392b` to `106ba1cd0d`)

These commits were ***rolled back***:

1. [PR #25 Added feature WW](https://github.com/four/pull/25)
1. [PR #24 Added milkshakes](https://github.com/four/pull/24)