### PR TITLE
use https URLs for uploading file to GitHub

### DIFF
--- a/lib/manifestly/repository.rb
+++ b/lib/manifestly/repository.rb
@@ -32,7 +32,7 @@ module Manifestly
 
       if repository.nil?
         remote_location = is_github_name?(github_name_or_path) ?
-                            "git@github.com:#{github_name_or_path}.git" :
+                            "https://github.com/#{github_name_or_path}.git" :
                             github_name_or_path
         Git.clone(remote_location, cached_path)
         repository = new(cached_path)


### PR DESCRIPTION
There were authentication problems. Also, I think it's the protocol preferred by GitHub
