### PR TITLE
Add --update option to `apply` to fetch if commit is missing

### DIFF
--- a/lib/manifestly/manifest.rb
+++ b/lib/manifestly/manifest.rb
@@ -30,9 +30,8 @@ module Manifestly
     end
 
     def self.read_file(filename, repositories)
-      File.open(filename, 'r') do |file|
-        read_lines(file, repositories)
-      end
+      lines = File.read(filename)
+      read_lines(lines, repositories)
     end
 
     def self.read_lines(lines, repositories)

--- a/lib/manifestly/manifest_item.rb
+++ b/lib/manifestly/manifest_item.rb
@@ -26,8 +26,8 @@ module Manifestly
       @repository.fetch
     end
 
-    def checkout_commit!
-      @repository.checkout_commit(@commit.sha)
+    def checkout_commit!(fetch_if_unfound=false)
+      @repository.checkout_commit(@commit.sha, fetch_if_unfound)
     end
 
     def to_file_string


### PR DESCRIPTION
Adds `--update` option to `manifestly apply`, which will `git fetch` in a repository if it does not have the commit listed in the manifest being applied.  

Here are the commands showing how it works.  The `tutor-js` repository was out of date for the commit referenced in the manifest I was trying to apply.  The first time I called `apply` without `--update`, and I got an error message.  The next time I called it with `--update` and it fetched and set the repository to the requested commit.

```
$> cd tutor-js; git rev-parse HEAD
e45b8d1a74327f973a43951292b28f0ca187fd69

$> more /tmp/my.manifest 
openstax/tutor-js @ 64b1dfd31c0197d78e6d71095e8621aa943bd6fb

$> cd ../manifestly

$> manifestly apply --file=/tmp/my.manifest --search-paths=..
Could not find commit 64b1dfd31c0197d78e6d71095e8621aa943bd6fb in repository 
openstax/tutor-js. Try running again with the `--update` option.

$> manifestly apply --file=/tmp/my.manifest --search-paths=.. --update

$> cd ../tutor-js

$> git rev-parse HEAD
64b1dfd31c0197d78e6d71095e8621aa943bd6fb
```

Also fixed a bug whereby I don't think that `apply` could have been working (ever since we added tagging to manifestly).