### PR TITLE
upload command returns manifest sha

### DIFF
--- a/lib/manifestly/cli.rb
+++ b/lib/manifestly/cli.rb
@@ -234,7 +234,7 @@ module Manifestly
 
     end
 
-    desc "upload", "Upload a local manifest file to a manifest repository"
+    desc "upload", "Upload a local manifest file to a manifest repository and print its SHA"
     file_option("upload")
     repo_option
     repo_file_option("The name of the manifest to upload to in the repository, with path if applicable")
@@ -246,15 +246,16 @@ module Manifestly
     long_desc <<-DESC
       Upload a manifest when you want to share it with others or persist it
       permanently.  Since manifests are stored remotely as versions of a file
-      in git, it cannot be changed once uploaded.
+      in git, it cannot be changed once uploaded.  Prints out the manifest SHA.
     DESC
     def upload
       repository = Repository.load_cached(options[:repo], update: true)
 
       begin
         repository.push_file!(options[:file], options[:repo_file], options[:message])
-      rescue Manifestly::Repository::ManifestUnchanged => e
-        say "The manifest you requested to push is already the latest and so could not be pushed."
+      rescue Manifestly::Repository::ManifestUnchanged
+      ensure
+        say repository.current_commit
       end
     end
 

--- a/lib/manifestly/repository.rb
+++ b/lib/manifestly/repository.rb
@@ -88,7 +88,7 @@ module Manifestly
       full_repository_file_path = File.join(@path, repository_file_path)
       FileUtils.cp(local_file_path, full_repository_file_path)
       git.add(repository_file_path)
-      raise ManifestUnchanged if git.status.changed.empty?
+      raise ManifestUnchanged if git.status.changed.empty? && git.status.added.empty?
       git.commit(message)
       git.push
     end

--- a/lib/manifestly/version.rb
+++ b/lib/manifestly/version.rb
@@ -1,3 +1,3 @@
 module Manifestly
-  VERSION = "2.2.1"
+  VERSION = "2.3.0"
 end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -125,4 +125,27 @@ describe Manifestly::Repository do
     end
   end
 
+  it 'testing' do
+    # Need remote to be a bare repo to push to it http://stackoverflow.com/a/1784612/1664216
+    Scenarios.run(inline: <<-SETUP
+        git init -q remote
+        cd remote
+        touch file.txt
+        git add . && git commit -q -m "."
+        cd ..
+        git clone --bare -l remote remote.git
+        rm -rf remote
+        git clone -q remote.git local
+        touch another_file.txt
+        echo blah > another_file.txt
+      SETUP
+    ) do |dirs|
+      repo = Manifestly::Repository.load("#{dirs[:root]}/local")
+
+      repo.push_file!("#{dirs[:root]}/another_file.txt", "file.txt", "a message")
+
+      expect(`cd #{dirs[:root]}/remote.git\n git show HEAD:file.txt`).to eq "blah\n"
+    end
+  end
+
 end


### PR DESCRIPTION
Now, when you call `manifestly upload ...` the result of that command will return the SHA of the uploaded manifest.  This enables you to take that SHA and add tags to it so that you can later retrieve it.  

`manifestly upload` will also no longer complain if the manifest that you're trying to upload is identical to what's already been uploaded -- it will simply not do the `push` and return the SHA.

Small fix: changed `manifestly upload` so that it can upload to a previously-non-existing file on the server.