### PR TITLE
Fix bug where find didn't return shas

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ See `$> manifestly help diff`.
 ## Miscellaneous
 
 1. You can add comments to manifests using a `# comment here` style.  Blank lines and leading and trailing whitespace are ignored in manifests.
+2. `manifestly version` prints version information.
 
 ## Development
 

--- a/lib/manifestly/repository.rb
+++ b/lib/manifestly/repository.rb
@@ -18,6 +18,7 @@ module Manifestly
     class NoCommitsError < StandardError; end
     # class TagNotFound < StandardError; end
     class TagShaNotFound < StandardError; end
+    class ShaAlreadyTagged < StandardError; end
 
     # Returns an object if can load a git repository at the specified path,
     # otherwise nil
@@ -184,6 +185,9 @@ module Manifestly
 
       options[:push] ||= false
       options[:message] ||= "no message"
+
+      existing_shas = get_shas_with_tag(tag: options[:tag])
+      raise(ShaAlreadyTagged) if existing_shas.include?(options[:sha])
 
       filename = get_commit_filename(options[:sha])
       tag = "#{Time.now.utc.strftime("%Y%m%d-%H%M%S.%6N")}/#{::SecureRandom.hex(2)}/#{filename}/#{options[:tag]}"

--- a/spec/manifestly_spec.rb
+++ b/spec/manifestly_spec.rb
@@ -5,7 +5,7 @@ describe Manifestly do
     expect(Manifestly::VERSION).not_to be nil
   end
 
-  xit 'creates a manifest' do
+  xit 'creates a manifest interactively' do
     allow(Thor::LineEditor).to receive(:readline).and_return('a', '3', 'w', 'test.manifest')
 
     capture(:stdout) {


### PR DESCRIPTION
Previously `manifestly find` was just returning SHAs but not printing them out, which is kinda useless :-)  Fixed that.  Also, if you tag the same SHA with the same value over and over, it only sticks the first time.  Also added `manifestly version`.