### PR TITLE
Prevent repeat tags when input SHA is short form

### DIFF
--- a/exe/manifestly
+++ b/exe/manifestly
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'rubygems'
+require 'byebug'
 
 $LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
 

--- a/lib/manifestly/repository.rb
+++ b/lib/manifestly/repository.rb
@@ -81,7 +81,7 @@ module Manifestly
 
     def make_like_just_cloned!
       git.branch('master').checkout
-      git.fetch
+      git.fetch('origin', :tags => true)
       git.reset_hard('origin/master')
     end
 
@@ -187,7 +187,7 @@ module Manifestly
       options[:message] ||= "no message"
 
       existing_shas = get_shas_with_tag(tag: options[:tag])
-      raise(ShaAlreadyTagged) if existing_shas.include?(options[:sha])
+      raise(ShaAlreadyTagged) if existing_shas.any?{|existing| existing.match(/#{options[:sha]}/)}
 
       filename = get_commit_filename(options[:sha])
       tag = "#{Time.now.utc.strftime("%Y%m%d-%H%M%S.%6N")}/#{::SecureRandom.hex(2)}/#{filename}/#{options[:tag]}"

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -101,7 +101,7 @@ describe Manifestly::Repository do
       @local.tag_scoped_to_file(tag: 'release-to-qa', sha: @sha, message: 'hi', push: true)
 
       expect{
-        @local.tag_scoped_to_file(tag: 'release-to-qa', sha: @sha, message: 'hi', push: true)
+        @local.tag_scoped_to_file(tag: 'release-to-qa', sha: @sha[0..7], message: 'hi', push: true)
       }.to raise_error(Manifestly::Repository::ShaAlreadyTagged)
 
       expect(@local.git.tags.count).to eq 1


### PR DESCRIPTION
The check we were using previously looked for an exact match between a previously tagged SHA and the SHA passed to `manifestly tag`.  Since that input SHA could just be a few characters, exact match wasn't stopping repeat tags.