### PR TITLE
Handle remote-deleted tags

### DIFF
--- a/lib/manifestly/repository.rb
+++ b/lib/manifestly/repository.rb
@@ -81,6 +81,8 @@ module Manifestly
 
     def make_like_just_cloned!
       git.branch('master').checkout
+      # Blow away tags and fetch them back http://stackoverflow.com/a/5373319/1664216
+      git.tags.map{|tag| git.delete_tag(tag.name)}
       git.fetch('origin', :tags => true)
       git.reset_hard('origin/master')
     end


### PR DESCRIPTION
This won't happen that often, but when a tag was deleted on the remote manifest repo it wasn't being reflected locally and so manifestly prevented a new tag from being created (because it doesn't want to do repeats).  Uses a nice SO trick to delete tags locally that don't exist on remote any more.