### PR TITLE
add moving non-timestamp tags for easier repeated lookup

### DIFF
--- a/lib/manifestly/repository.rb
+++ b/lib/manifestly/repository.rb
@@ -192,15 +192,21 @@ module Manifestly
       raise(ShaAlreadyTagged) if existing_shas.any?{|existing| existing.match(/#{options[:sha]}/)}
 
       filename = get_commit_filename(options[:sha])
-      tag = "#{Time.now.utc.strftime("%Y%m%d-%H%M%S.%6N")}/#{::SecureRandom.hex(2)}/#{filename}/#{options[:tag]}"
-      git.add_tag(tag, options[:sha], {annotate: true, message: options[:message], f: true})
-      git.push('origin', "refs/tags/#{tag}", f: true) if options[:push]
+
+      plain_tag = "#{filename}/#{options[:tag]}"
+      git.add_tag(plain_tag, options[:sha], {annotate: true, message: options[:message], f: true})
+      git.push('origin', "refs/tags/#{plain_tag}", f: true) if options[:push]
+
+      unique_tag = "#{Time.now.utc.strftime("%Y%m%d-%H%M%S.%6N")}/#{::SecureRandom.hex(2)}/#{filename}/#{options[:tag]}"
+      git.add_tag(unique_tag, options[:sha], {annotate: true, message: options[:message], f: true})
+      git.push('origin', "refs/tags/#{unique_tag}", f: true) if options[:push]
     end
 
     def get_shas_with_tag(options={})
       options[:file] ||= ".*"
       options[:order] ||= :descending
 
+      # only look for the unique tags, not the plain ones
       pattern = /.*\/#{options[:file]}\/#{options[:tag]}/
 
       tag_objects = git.tags.select{|tag| tag.name.match(pattern)}

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -272,10 +272,11 @@ describe Manifestly::CLI do
           Manifestly::CLI.start(%W[find --repo=#{dirs[:root]}/remote --repo_file=foo.manifest --tag=release-to-qa --limit=1])
         }.chomp).to eq shas[2]
 
-        # Check that tags made it to remote
+        # Check that tags made it to remote; there should be 3 unique tags, and each file has one plain tag
+        # for a total of 5
 
         git = Git.open("#{dirs[:root]}/remote")
-        expect(git.tags.count).to eq 3
+        expect(git.tags.count).to eq 5
       end
     end
 
@@ -357,13 +358,14 @@ describe Manifestly::CLI do
           }
         ).to eq manifest_sha
 
-        # do it again to show that the duplicate tag doesn't stick (no error output and still just one tag)
+        # do it again to show that the duplicate tag doesn't stick (no error output and still just "one" tag,
+        # really there is a plain version and a unique version so the tag count should be 2)
 
         expect(capture(:stdout) {
           Manifestly::CLI.start(%W[tag --repo=#{dirs[:root]}/remote.git --sha=#{manifest_sha} --tag=release-to-qa --message="hi\ there"])
         }).to eq ""
 
-        expect(Git.ls_remote("#{dirs[:root]}/remote.git")["tags"].keys.reject{|kk| kk.match(/.*\^\{\}/)}.count).to eq 1
+        expect(Git.ls_remote("#{dirs[:root]}/remote.git")["tags"].keys.reject{|kk| kk.match(/.*\^\{\}/)}.count).to eq 2
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,3 +69,20 @@ RSpec::Matchers.define :exit_with_message do |expected_message|
     @failure_message || "expected the error message '#{@actual_message}' to match '#{expected_message}'"
   end
 end
+
+RSpec::Matchers.define :have_sha_tag do |sha,expected_tag|
+  include RSpec::Matchers::Composable
+
+  match do |git|
+    sha_tags = git.tags.select{|tag| tag.contents.match("object #{sha}")}
+    sha_tags.map(&:name).any?{|tag_value| tag_value.match(expected_tag)}
+  end
+
+  failure_message do |git|
+    "expected that #{git.dir} would have tag #{expected_tag} on sha #{sha}"
+  end
+
+  failure_message_when_negated do |git|
+    "expected that #{git.dir} would not have tag #{expected_tag} on sha #{sha}"
+  end
+end


### PR DESCRIPTION
Now when you tag a manifest, you get the unique version of it that we've always had, e.g.:

`20160903-171525.789660/61b7/file.txt/release-to-qa`

and a new "plain" version that doesn't have the timestamp and random characters:

`file.txt/release-to-qa`

When you repeatedly tag with the same value like `release-to-qa`, the "plain" version will be removed from prior sha that was tagged and will be added to the most recently provided sha.  The unique value tags will always remain where they were originally tagged so we maintain a history of what was tagged when.