### PR TITLE
new manifest format with explicit dirs and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ To update to the latest version:
 A manifest is simple: just a file listing off repositories at specified commits, e.g.:
 
 ```
-my_github_org/application_1 @ fb186400247779f90aacf23fa2cde044cbac387c
-my_github_org/application_2 @ c4eb68d6b16f61af04dd0e02df2249382d411104
+[directory_1] my_github_org/application_1@fb18640024
+[directory_2] my_github_org/application_2@c4eb68d6b1 # v1.2.3
 ```
 
 When you have deploys that span multiple applications, a manifest lets you identify exactly what is deployed for each app.
 This tool, Manifestly, helps you create, find, and use these manifests in your deploy infrastructure.
+
+_Note: By including repository source directories, manifestly helps support cases where one repository holds the source for multiple deployments.  Manifestly will also include tag names for the indicated commit at the end of each line in a comment._
 
 ## Usage
 

--- a/lib/manifestly/manifest_item.rb
+++ b/lib/manifestly/manifest_item.rb
@@ -30,26 +30,79 @@ module Manifestly
       @repository.checkout_commit(@commit.sha, fetch_if_unfound)
     end
 
+    def commit_tags
+      @repository.git.tags.select do |tag|
+        # Gotta do some digging to get tagged sha out of annotated tags
+        tagged_sha = tag.annotated? ?
+                     tag.contents_array[0].split(" ").last == commit :
+                     tag.sha
+
+        tagged_sha == commit.sha
+      end.map(&:name)
+    end
+
     def to_file_string
-      "#{repository_name} @ #{commit.sha}"
+      dir = @repository.deepest_working_dir
+      repo = @repository.github_name_or_path
+      tags = commit_tags
+
+      "[#{dir}]#{repo.nil? ? '' : ' ' + repo}@#{commit.sha[0..9]}#{' # ' + tags.join(",") if tags.any?}"
     end
 
     def self.from_file_string(string, repositories)
-      repo_name, sha = string.split('@').collect(&:strip)
-      raise(InvalidManifestItem, string) if repo_name.blank? || sha.blank?
+      repo_name, dir, sha = parse_file_string(string)
 
       matching_repositories = repositories.select do |repo|
-        repo.display_name == repo_name
+        repo.github_name_or_path == repo_name &&
+        repo.deepest_working_dir == dir
       end
 
-      raise(MultipleSameNameRepositories, repo_name) if matching_repositories.size > 1
-      raise(RepositoryNotFound, repo_name) if matching_repositories.empty?
+      # TODO test these two exceptions!
+      raise(MultipleSameNameRepositories, repo_display_name) if matching_repositories.size > 1
+      raise(RepositoryNotFound, repo_display_name) if matching_repositories.empty?
 
       repository = matching_repositories.first
 
       item = ManifestItem.new(repository)
       item.set_commit_by_sha(sha)
       item
+    end
+
+    def self.parse_file_string(string)
+      sha_re = "([a-fA-F0-9]+)"
+      repo_re = '([\w-]+\/[\w-]+)'
+      old_dir_re_1 = '\((.*)\)'
+      old_dir_re_2 = '(.*)'
+      new_dir_re = '\[(.*)\]'
+
+      # New style: `[dir] org/repo@sha`
+      if string =~ /#{new_dir_re}\W*#{repo_re}\W*@\W*#{sha_re}/
+        dir = $1.strip
+        repo_name = $2.strip
+        sha = $3.strip
+      # New style where there is no GH repo: `[dir]@sha`
+      elsif string =~ /#{new_dir_re}\W*@\W*#{sha_re}/
+        dir = $1.strip
+        sha = $2.strip
+      # Old style with dir shown: `org/repo (dir) @ sha`
+      elsif string =~ /#{repo_re}\W*#{old_dir_re_1}\W*@\W*#{sha_re}/
+        repo_name = $1.strip
+        dir = $2.strip
+        sha = $3.strip
+      # Old style with implicit dir: `org/repo @ sha`
+      elsif string =~ /#{repo_re}\W*@\W*#{sha_re}/
+        repo_name = $1.strip
+        sha = $2.strip
+        dir = repo_name.split('/').last
+      # Old style with no repo: `dir @ sha`
+      elsif string =~ /#{old_dir_re_2}\W*@\W*#{sha_re}/
+        dir = $1.strip
+        sha = $2.strip
+      else
+        raise(InvalidManifestItem, string)
+      end
+
+      [repo_name, dir, sha]
     end
 
     attr_accessor :commit

--- a/lib/manifestly/manifest_item.rb
+++ b/lib/manifestly/manifest_item.rb
@@ -53,13 +53,19 @@ module Manifestly
       repo_name, dir, sha = parse_file_string(string)
 
       matching_repositories = repositories.select do |repo|
-        repo.github_name_or_path == repo_name &&
+        # directory name will be the most unique way to match and should always be available
+        # wheres repo_name won't always be
         repo.deepest_working_dir == dir
       end
 
       # TODO test these two exceptions!
-      raise(MultipleSameNameRepositories, repo_display_name) if matching_repositories.size > 1
-      raise(RepositoryNotFound, repo_display_name) if matching_repositories.empty?
+      if matching_repositories.size > 1
+        raise(MultipleSameNameRepositories, "Dir: [#{dir}], Repo: [#{repo_name}]")
+      end
+
+      if matching_repositories.empty?
+        raise(RepositoryNotFound, "Dir: [#{dir}], Repo: [#{repo_name}]")
+      end
 
       repository = matching_repositories.first
 

--- a/lib/manifestly/repository.rb
+++ b/lib/manifestly/repository.rb
@@ -244,11 +244,7 @@ module Manifestly
     end
 
     def display_name
-      if github_name_or_path
-        github_name_or_path + " (#{deepest_working_dir})"
-      else
-        deepest_working_dir
-      end
+      "[#{deepest_working_dir}]#{' ' + github_name_or_path if !github_name_or_path.nil?}"
     end
 
     protected

--- a/lib/manifestly/repository.rb
+++ b/lib/manifestly/repository.rb
@@ -239,17 +239,15 @@ module Manifestly
       git.dir
     end
 
+    def deepest_working_dir
+      working_dir.to_s.split(File::SEPARATOR).last
+    end
+
     def display_name
       if github_name_or_path
-        repo_name = github_name_or_path.split('/').last
-        dir_name = working_dir.to_s.split(File::SEPARATOR).last
-        if repo_name == dir_name
-          github_name_or_path
-        else
-          github_name_or_path + " (#{dir_name})"
-        end
+        github_name_or_path + " (#{deepest_working_dir})"
       else
-        working_dir.to_s.split('/').last
+        deepest_working_dir
       end
     end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -12,7 +12,7 @@ describe Manifestly::CLI do
           touch some_file
           git add . && git commit -q -m "."
           git rev-parse HEAD > ../../sha_0.txt
-          echo "one @ `git rev-parse HEAD`" > ../../my.manifest
+          echo "one @ `git rev-parse HEAD | cut -c1-10`" > ../../my.manifest
           echo blah > some_file
           git add . && git commit -q -m "."
           git rev-parse HEAD > ../../sha_1.txt
@@ -312,6 +312,9 @@ describe Manifestly::CLI do
           fake_commit | repo:four | comment: Another commit
           fake_commit | repo:four | comment: Merge pull request #24 from org/howdy Added milkshakes
           fake_commit | repo:four | comment: Merge pull request #25 from org/howdy Added feature WW | sha:SHA7
+          cd four
+          git remote add origin git@github.com:org/repo2.git
+          cd ..
           git init -q manifests
           cd manifests
           echo one @ "${SHA1}" >> foo
@@ -333,7 +336,7 @@ describe Manifestly::CLI do
 
         result = Manifestly::CLI.start(%W[diff --search_paths=#{dirs[:root]} --repo=#{dirs[:root]}/manifests --from_sha=#{manifest_shas[0]} --to_sha=#{manifest_shas[1]}])
 
-        expect(result).to match /Manifest Diff\n\n.*foo.*manifests.*\n\n## one.*\n\n.*PR #2 Added.*\n.*PR #1.*\n\n## two.*\n\n\* There.*\n\n## three.*\n\n\* This.*\n\n## four.*\n\n.*rolled back.*\n\n.*\[PR #25.*\n.*PR #24.*/
+        expect(result).to match /Manifest Diff\n\n.*foo.*manifests.*\n\n## \[one.*\n\n.*PR #2 Added.*\n.*PR #1.*\n\n## \[two.*\n\n\* There.*\n\n## \[three.*\n\n\* This.*\n\n## \[four\] org\/repo2.*\n\n.*rolled back.*\n\n.*\[PR #25.*\n.*PR #24.*/
       end
 
     end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -103,6 +103,7 @@ describe Manifestly::CLI do
           mkdir repos && cd repos
           git init -q one
           cd one
+          git remote add origin https://github.com/org/repo.git
           touch some_file
           git add . && git commit -q -m "."
           git rev-parse HEAD > ../../sha_0.txt
@@ -111,10 +112,19 @@ describe Manifestly::CLI do
           cd two
           touch other_file
           git add . && git commit -q -m "."
+          git tag -a v8.7 -m "howdy"
           git rev-parse HEAD > ../../sha_1.txt
+          cd ..
+          git init -q three
+          cd three
+          git remote add origin git@github.com:org/repo2.git
+          touch some_file
+          git add . && git commit -q -m "."
+          git tag v1.2.3
+          git rev-parse HEAD > ../../sha_2.txt
         SETUP
       ) do |dirs|
-        shas = %w(sha_0 sha_1).collect do |sha|
+        shas = %w(sha_0 sha_1 sha_2).collect do |sha|
           File.open("#{dirs[:root]}/#{sha}.txt").read.chomp
         end
 
@@ -125,8 +135,9 @@ describe Manifestly::CLI do
         manifest = File.open("#{dirs[:root]}/my.manifest").read
 
         expect(manifest).to eq(
-          "one @ #{shas[0]}\n" \
-          "two @ #{shas[1]}\n"
+          "[one] org/repo@#{std_sha(shas[0])}\n" \
+          "[three] org/repo2@#{std_sha(shas[2])} # v1.2.3\n" \
+          "[two]@#{std_sha(shas[1])}\n"
         )
       end
     end

--- a/spec/manifest_item_spec.rb
+++ b/spec/manifest_item_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe Manifestly::ManifestItem do
+
+  describe "#parse_file_string" do
+
+    context "original style" do
+      context "directory present" do
+        it "handles spaces" do
+          test_parse("org/repo (dir) @ deadbeef", repo: "org/repo", dir: "dir", sha: "deadbeef")
+        end
+
+        it "handles no spaces" do
+          test_parse("org/repo(dir)@deadbeef", repo: "org/repo", dir: "dir", sha: "deadbeef")
+        end
+
+        it "handles comments" do
+          test_parse("org/repo(dir)@deadbeef#blah", repo: "org/repo", dir: "dir", sha: "deadbeef")
+        end
+      end
+
+      context "directory absent" do
+        it "handles spaces" do
+          test_parse("org/repo    @ deadbeef", repo: "org/repo", dir: "repo", sha: "deadbeef")
+        end
+
+        it "handles no spaces" do
+          test_parse("org/repo@deadbeef", repo: "org/repo", dir: "repo", sha: "deadbeef")
+        end
+
+        it "handles comments" do
+          test_parse("org/repo    @ deadbeef #blah ", repo: "org/repo", dir: "repo", sha: "deadbeef")
+        end
+      end
+
+      context "repo absent" do
+        it "handles spaces" do
+          test_parse("dir    @ deadbeef", repo: nil, dir: "dir", sha: "deadbeef")
+        end
+
+        it "handles no spaces" do
+          test_parse("dir@deadbeef", repo: nil, dir: "dir", sha: "deadbeef")
+        end
+
+        it "handles comments" do
+          test_parse("dir@ deadbeef #blah ", repo: nil, dir: "dir", sha: "deadbeef")
+        end
+      end
+    end
+
+    context "new style" do
+      context "repo present" do
+        it "works with spaces" do
+          test_parse("[directory] org/repo @ deadbeef", repo: "org/repo", dir: "directory", sha: "deadbeef")
+        end
+
+        it "works without spaces" do
+          test_parse("[directory]org/a-repo@deadbeef", repo: "org/a-repo", dir: "directory", sha: "deadbeef")
+        end
+
+        it "works with comments" do
+          test_parse("[directory]org/repo@deadbeef # blah", repo: "org/repo", dir: "directory", sha: "deadbeef")
+        end
+      end
+
+      context "repo absent" do
+        it "works with spaces" do
+          test_parse("[directory] @ deadbeef", repo: nil, dir: "directory", sha: "deadbeef")
+        end
+
+        it "works without spaces" do
+          test_parse("[directory]@deadbeef", repo: nil, dir: "directory", sha: "deadbeef")
+        end
+
+        it "works with comments" do
+          test_parse("[directory] @ deadbeef # blah", repo: nil, dir: "directory", sha: "deadbeef")
+        end
+      end
+    end
+
+  end
+
+  def test_parse(string, repo:, dir:, sha:)
+    expect(described_class.parse_file_string(string)).to eq [repo, dir, sha]
+  end
+end

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -18,4 +18,37 @@ describe Manifestly::Manifest do
       ])
     end
   end
+
+  describe "create manifest from file" do
+
+    context "old format without repo in manifest" do
+      # Somewhat contrived example, b/c a manifest made from this scenario would
+      # normally include the repo.
+
+      it 'loads fine' do
+        Scenarios.run(inline: <<-SETUP
+            mkdir repos && cd repos
+            git init -q one
+            cd one
+            touch some_file
+            git add . && git commit -q -m "."
+            git remote add origin git@github.com:org/my-repo.git
+            git rev-parse HEAD > ../../sha_0.txt
+            echo "one @ `git rev-parse HEAD`" > ../../my.manifest
+            echo blah > some_file
+            git add . && git commit -q -m "."
+            git rev-parse HEAD > ../../sha_1.txt
+          SETUP
+        ) do | dirs|
+
+          repositories = [Manifestly::Repository.load("#{dirs[:root]}/repos/one")]
+
+          expect{
+            manifest = described_class.read_file("#{dirs[:root]}/my.manifest", repositories)
+          }.not_to raise_error
+        end
+      end
+    end
+
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,10 @@ RSpec.configure do |config|
       $stdout = original_stdout
     end
   end
+
+  def std_sha(sha)
+    sha[0..9]
+  end
 end
 
 RSpec::Matchers.define :exit_with_message do |expected_message|


### PR DESCRIPTION
Changes manifestly to have a new manifest format (while still being about to read old formats)

The new format looks like so:

```
[directory_1] my_github_org/application_1@fb18640024
[directory_2] my_github_org/application_2@c4eb68d6b1 # v1.2.3
```

Tags will be appended to lines in a comment if there are any on the indicated sha.  Directories will always be included in brackets at the start of each line.  The repository name may not be included if the repository being manifested does not have a github remote, in which case the manifest lines will look like:

```
[directory_1]@fb18640024
```