### PR TITLE
Add option to output full SHAs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.manifest
 .manifestly
 *.*~
+.byebug_history

--- a/lib/manifestly/cli.rb
+++ b/lib/manifestly/cli.rb
@@ -95,6 +95,11 @@ module Manifestly
                   banner: '',
                   required: false,
                   default: ''
+    method_option :full_shas,
+                  desc: "Use full instead of shortened SHAs",
+                  type: :boolean,
+                  default: false,
+                  required: false
     long_desc <<-DESC
       Creates a manifest.
 
@@ -508,7 +513,7 @@ module Manifestly
 
       filename = default_filename if filename.blank?
 
-      manifest.write(filename)
+      manifest.write(filename, options.slice("full_shas"))
     end
 
     def present_commit_menu(manifest_item, options={})

--- a/lib/manifestly/manifest.rb
+++ b/lib/manifestly/manifest.rb
@@ -53,11 +53,11 @@ module Manifestly
       end
     end
 
-    def write(filename)
+    def write(filename, options={})
       File.open(filename, 'w') do |file|
         @items.sort_by!(&:repository_name)
         @items.each do |item|
-          file.write(item.to_file_string + "\n")
+          file.write(item.to_file_string(options) + "\n")
         end
       end
     end

--- a/lib/manifestly/manifest_item.rb
+++ b/lib/manifestly/manifest_item.rb
@@ -41,12 +41,15 @@ module Manifestly
       end.map(&:name)
     end
 
-    def to_file_string
+    def to_file_string(options={})
+      options[:full_shas] ||= false
+
       dir = @repository.deepest_working_dir
       repo = @repository.github_name_or_path
       tags = commit_tags
+      sha = options[:full_shas] ? commit.sha : commit.sha[0..9]
 
-      "[#{dir}]#{repo.nil? ? '' : ' ' + repo}@#{commit.sha[0..9]}#{' # ' + tags.join(",") if tags.any?}"
+      "[#{dir}]#{repo.nil? ? '' : ' ' + repo}@#{sha}#{' # ' + tags.join(",") if tags.any?}"
     end
 
     def self.from_file_string(string, repositories)

--- a/lib/manifestly/utilities.rb
+++ b/lib/manifestly/utilities.rb
@@ -11,6 +11,11 @@ class Hash
   def except(*keys)
     dup.except!(*keys)
   end
+
+  def slice(*keys)
+    keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
+    keys.each_with_object(self.class.new) { |k, hash| hash[k] = self[k] if has_key?(k) }
+  end
 end
 
 class String


### PR DESCRIPTION
When creating a manifest, you can specify a `--full-shas=true` option so that manifests use the full-length SHAs instead of just the first 10 characters.